### PR TITLE
ensure standard shell is used under windows to pass correct glob command

### DIFF
--- a/plugin/ctrlspace.vim
+++ b/plugin/ctrlspace.vim
@@ -2794,6 +2794,10 @@ function! <SID>kill(plugin_buffer, final)
   if exists("b:nossl_save") && b:nossl_save
     set nossl
   endif
+  " cmdline support for win32
+  if exists("b:savedShell")
+    let [&shell, &shellcmdflag, &shellxquote, &shellxescape, &shellquote, &shellpipe, &shellredir]=b:savedShell
+  endif
 
   if a:plugin_buffer
     silent! exe ':' . a:plugin_buffer . 'bwipeout'
@@ -4362,6 +4366,11 @@ function! <SID>set_up_buffer()
   if has("win32") && !&ssl
     let b:nossl_save = 1
     set ssl
+  endif
+
+  if has("win32")
+    let b:savedShell=[&shell, &shellcmdflag, &shellxquote, &shellxescape, &shellquote, &shellpipe, &shellredir]
+    set shell=cmd shellcmdflag=/c shellxquote=\" shellquote= shellpipe=> shellredir=>%s\ 2>&1
   endif
 
   augroup CtrlSpaceUpdateSearch


### PR DESCRIPTION
Dear Szymon,

This commit ensures that under MS Windows always the standard shell (that is 'cmd' and not 'powershell', 'Korn Shell', ...) with standard parameters is used to invoke all bang commands. 

Otherwise, for example the glob command fails, if customized by the user.