### PR TITLE
Use system instead of systemlist.

### DIFF
--- a/plugin/ctrlspace.vim
+++ b/plugin/ctrlspace.vim
@@ -2449,7 +2449,7 @@ function! <SID>ctrlspace_toggle(internal)
 
         let unique_files = {}
 
-        for fname in empty(g:ctrlspace_glob_command) ? split(globpath('.', '**'), '\n') : systemlist(g:ctrlspace_glob_command)
+        for fname in empty(g:ctrlspace_glob_command) ? split(globpath('.', '**'), '\n') : split(system(g:ctrlspace_glob_command), '\n')
           let fname_modified = fnamemodify(has("win32") ? substitute(fname, "\r$", "", "") : fname, ":.")
 
           if isdirectory(fname_modified) || (fname_modified =~# g:ctrlspace_ignored_files)


### PR DESCRIPTION
`systemlist()` is relatively new and introduced from version 7.4.248.
Better to use `system()` for better backward compatibility.

https://code.google.com/p/vim/source/detail?r=e5f1f2ea0b4a4834791924880f78272ef52eb087