### PR TITLE
Expand file paths to allow editing files using ~/foo tilde-paths

### DIFF
--- a/plugin/ctrlspace.vim
+++ b/plugin/ctrlspace.vim
@@ -5537,6 +5537,7 @@ function! <SID>edit_file()
     return
   endif
 
+  let new_file = expand(new_file)
   if !<SID>ensure_path(new_file)
     return
   endif


### PR DESCRIPTION
Failure to expand the path causes vim to try to create a
directory when it already exists.

We wrongfully detect that the directory does not exist and try
to create it.  The error occurs because we are creating a
directory that already exists.

Expand the path so that the directory's existence is properly
detected.